### PR TITLE
feat: add SkipAll result and WithRateLimiter builder

### DIFF
--- a/conditions/manager.go
+++ b/conditions/manager.go
@@ -16,6 +16,7 @@ const (
 	ReasonComplete = "Complete"
 	ReasonPending  = "Pending"
 	ReasonStopped  = "Stopped"
+	ReasonSkipped  = "Skipped"
 	ReasonError    = "Error"
 	ReasonUnknown  = "Unknown"
 )
@@ -83,6 +84,32 @@ func (m *Manager) SetSubroutineCondition(obj client.Object, name string, result 
 
 	conditions := accessor.GetConditions()
 	meta.SetStatusCondition(&conditions, cond)
+	accessor.SetConditions(conditions)
+}
+
+// SetSkippedConditions sets conditions for the given subroutine names to Skipped.
+// When ready is true, condition status is True; when false, condition status is False.
+func (m *Manager) SetSkippedConditions(obj client.Object, names []string, ready bool, msg string) {
+	accessor, ok := obj.(ConditionAccessor)
+	if !ok {
+		return
+	}
+
+	status := metav1.ConditionFalse
+	if ready {
+		status = metav1.ConditionTrue
+	}
+
+	conditions := accessor.GetConditions()
+	for _, name := range names {
+		meta.SetStatusCondition(&conditions, metav1.Condition{
+			Type:               name,
+			Status:             status,
+			Reason:             ReasonSkipped,
+			Message:            msg,
+			ObservedGeneration: obj.GetGeneration(),
+		})
+	}
 	accessor.SetConditions(conditions)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/trace v1.36.0
 	k8s.io/apimachinery v0.35.0
+	k8s.io/client-go v0.35.0
 	sigs.k8s.io/controller-runtime v0.23.1
 	sigs.k8s.io/multicluster-runtime v0.23.1
 )
@@ -25,7 +26,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -47,7 +47,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
@@ -59,7 +58,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.35.0 // indirect
 	k8s.io/apiextensions-apiserver v0.35.0 // indirect
-	k8s.io/client-go v0.35.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/lifecycle/interfaces.go
+++ b/lifecycle/interfaces.go
@@ -11,6 +11,7 @@ import (
 type ConditionManager interface {
 	InitUnknownConditions(obj client.Object, subroutineNames []string)
 	SetSubroutineCondition(obj client.Object, name string, result subroutines.Result, err error, isFinalize bool)
+	SetSkippedConditions(obj client.Object, names []string, ready bool, msg string)
 	SetReadyCondition(obj client.Object, reason string)
 }
 

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
 )
 
 var tracer = otel.Tracer("github.com/platform-mesh/subroutines/lifecycle")
@@ -51,6 +52,7 @@ type Lifecycle struct {
 	specPatch      bool
 	initializer    string
 	terminator     string
+	rateLimiter    workqueue.TypedRateLimiter[reconcile.Request]
 }
 
 // New creates a Lifecycle for the given controller.
@@ -125,6 +127,20 @@ func (l *Lifecycle) WithInitializer(name string) *Lifecycle {
 func (l *Lifecycle) WithTerminator(name string) *Lifecycle {
 	l.terminator = name
 	return l
+}
+
+// WithRateLimiter sets a custom rate limiter for the controller's work queue.
+// This controls how fast items re-enter the queue, independent of subroutine-level
+// requeue timing. Accepts any workqueue.TypedRateLimiter implementation.
+func (l *Lifecycle) WithRateLimiter(limiter workqueue.TypedRateLimiter[reconcile.Request]) *Lifecycle {
+	l.rateLimiter = limiter
+	return l
+}
+
+// RateLimiter returns the configured rate limiter, or nil if none was set.
+// This is used by controller setup code to configure the controller's work queue.
+func (l *Lifecycle) RateLimiter() workqueue.TypedRateLimiter[reconcile.Request] {
+	return l.rateLimiter
 }
 
 // Reconcile implements mcreconcile.Reconciler.
@@ -218,10 +234,12 @@ func (l *Lifecycle) Reconcile(ctx context.Context, req mcreconcile.Request) (rec
 		subroutineErr error
 		hasPending    bool
 		hasStopped    bool
+		hasSkipAll    bool
+		skipAllReady  bool
 		minRequeue    time.Duration
 	)
 
-	for _, sub := range subs {
+	for i, sub := range subs {
 		action, actionName := l.resolveAction(ctx, sub, obj, isDeleting)
 		if action == nil {
 			continue
@@ -284,10 +302,27 @@ func (l *Lifecycle) Reconcile(ctx context.Context, req mcreconcile.Request) (rec
 			logger.Info("subroutine stopped the chain", "subroutine", sub.GetName(), "action", actionName, "message", result.Message())
 			break
 		}
+
+		if result.IsSkipAll() {
+			hasSkipAll = true
+			skipAllReady = result.Ready()
+			logger.Info("subroutine skipped remaining chain", "subroutine", sub.GetName(), "action", actionName, "message", result.Message(), "ready", result.Ready())
+			// Set remaining subroutines' conditions to Skipped.
+			if l.conditions != nil {
+				var remaining []string
+				for _, r := range subs[i+1:] {
+					remaining = append(remaining, r.GetName())
+				}
+				if len(remaining) > 0 {
+					l.conditions.SetSkippedConditions(obj, remaining, skipAllReady, result.Message())
+				}
+			}
+			break
+		}
 	}
 
 	// Remove initializer/terminator from status if all succeeded with no requeue.
-	if subroutineErr == nil && !hasStopped && !hasPending && minRequeue == 0 {
+	if subroutineErr == nil && !hasStopped && !hasSkipAll && !hasPending && minRequeue == 0 {
 		if l.initializer != "" && !isDeleting {
 			if removeMarkerFromStatus(ctx, obj, statusFieldInitializers, l.initializer) {
 				logger.V(1).Info("removed initializer from status", "initializer", l.initializer)
@@ -307,6 +342,8 @@ func (l *Lifecycle) Reconcile(ctx context.Context, req mcreconcile.Request) (rec
 		case subroutineErr != nil:
 			readyReason = conditions.ReasonError
 		case hasStopped:
+			readyReason = conditions.ReasonStopped
+		case hasSkipAll && !skipAllReady:
 			readyReason = conditions.ReasonStopped
 		case hasPending:
 			readyReason = conditions.ReasonPending

--- a/result.go
+++ b/result.go
@@ -9,6 +9,7 @@ const (
 	actionPending
 	actionStopWithRequeue
 	actionStop
+	actionSkipAll
 )
 
 // Result encodes the outcome of a subroutine invocation.
@@ -17,6 +18,7 @@ type Result struct {
 	action  action
 	requeue time.Duration
 	message string
+	ready   bool
 }
 
 // OK returns a Result that continues the chain with no requeue.
@@ -51,6 +53,13 @@ func Stop(msg string) Result {
 	return Result{action: actionStop, message: msg}
 }
 
+// SkipAll halts the subroutine chain and marks remaining subroutines as Skipped.
+// The ready flag controls the aggregate Ready condition: true sets it to True,
+// false sets it to False.
+func SkipAll(ready bool, msg string) Result {
+	return Result{action: actionSkipAll, message: msg, ready: ready}
+}
+
 // IsContinue returns true if the result is OK or OKWithRequeue.
 // Note: Pending also continues the chain but returns false here — use IsPending
 // to check for that case separately.
@@ -71,6 +80,16 @@ func (r Result) IsStopWithRequeue() bool {
 // IsStop returns true if the result stops the chain with no requeue.
 func (r Result) IsStop() bool {
 	return r.action == actionStop
+}
+
+// IsSkipAll returns true if the result halts the chain and marks remaining subroutines as Skipped.
+func (r Result) IsSkipAll() bool {
+	return r.action == actionSkipAll
+}
+
+// Ready returns the ready flag, which controls the aggregate Ready condition for SkipAll results.
+func (r Result) Ready() bool {
+	return r.ready
 }
 
 // Requeue returns the requeue duration.


### PR DESCRIPTION
## Summary

Implements the two remaining features from [RFC 003](https://github.com/platform-mesh/architecture/pull/9) that were missing from the initial lifecycle engine v2:

- **`SkipAll(ready, message)`** — Halts the subroutine chain and marks remaining subroutines' conditions as `Skipped`. The `ready` flag controls both the remaining conditions' status (True/False) and the aggregate Ready condition. Use cases: early completion when resource is already up-to-date, or feature gate disabling all processing.

- **`WithRateLimiter(limiter)`** — Configures a custom work queue rate limiter on the Lifecycle, exposed via `RateLimiter()` for controller setup code to pass to `controller.Options`. Accepts any `workqueue.TypedRateLimiter[reconcile.Request]`.

Also fixes the build — tests for these features were merged in #1 but the implementation was missing.

## Changes

- `result.go`: Add `actionSkipAll`, `ready` field, `SkipAll()` factory, `IsSkipAll()`/`Ready()` accessors
- `conditions/manager.go`: Add `ReasonSkipped` constant and `SetSkippedConditions()` method
- `lifecycle/interfaces.go`: Add `SetSkippedConditions` to `ConditionManager` interface
- `lifecycle/lifecycle.go`: SkipAll handling in reconcile loop, `rateLimiter` field, `WithRateLimiter()`/`RateLimiter()` methods
- `go.mod`: Promote `k8s.io/client-go` to direct dependency