### PR TITLE
feat: add SkipAll result for early chain completion

### DIFF
--- a/conditions/manager.go
+++ b/conditions/manager.go
@@ -16,6 +16,7 @@ const (
 	ReasonComplete = "Complete"
 	ReasonPending  = "Pending"
 	ReasonStopped  = "Stopped"
+	ReasonSkipped  = "Skipped"
 	ReasonError    = "Error"
 	ReasonUnknown  = "Unknown"
 )
@@ -83,6 +84,32 @@ func (m *Manager) SetSubroutineCondition(obj client.Object, name string, result 
 
 	conditions := accessor.GetConditions()
 	meta.SetStatusCondition(&conditions, cond)
+	accessor.SetConditions(conditions)
+}
+
+// SetSkippedConditions sets conditions for the given subroutine names to Skipped.
+// When ready is true, condition status is True; when false, condition status is False.
+func (m *Manager) SetSkippedConditions(obj client.Object, names []string, ready bool, msg string) {
+	accessor, ok := obj.(ConditionAccessor)
+	if !ok {
+		return
+	}
+
+	status := metav1.ConditionFalse
+	if ready {
+		status = metav1.ConditionTrue
+	}
+
+	conditions := accessor.GetConditions()
+	for _, name := range names {
+		meta.SetStatusCondition(&conditions, metav1.Condition{
+			Type:               name,
+			Status:             status,
+			Reason:             ReasonSkipped,
+			Message:            msg,
+			ObservedGeneration: obj.GetGeneration(),
+		})
+	}
 	accessor.SetConditions(conditions)
 }
 

--- a/lifecycle/interfaces.go
+++ b/lifecycle/interfaces.go
@@ -11,6 +11,7 @@ import (
 type ConditionManager interface {
 	InitUnknownConditions(obj client.Object, subroutineNames []string)
 	SetSubroutineCondition(obj client.Object, name string, result subroutines.Result, err error, isFinalize bool)
+	SetSkippedConditions(obj client.Object, names []string, ready bool, msg string)
 	SetReadyCondition(obj client.Object, reason string)
 }
 

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -218,10 +218,12 @@ func (l *Lifecycle) Reconcile(ctx context.Context, req mcreconcile.Request) (rec
 		subroutineErr error
 		hasPending    bool
 		hasStopped    bool
+		hasSkipAll    bool
+		skipAllReady  bool
 		minRequeue    time.Duration
 	)
 
-	for _, sub := range subs {
+	for i, sub := range subs {
 		action, actionName := l.resolveAction(ctx, sub, obj, isDeleting)
 		if action == nil {
 			continue
@@ -284,10 +286,26 @@ func (l *Lifecycle) Reconcile(ctx context.Context, req mcreconcile.Request) (rec
 			logger.Info("subroutine stopped the chain", "subroutine", sub.GetName(), "action", actionName, "message", result.Message())
 			break
 		}
+
+		if result.IsSkipAll() {
+			hasSkipAll = true
+			skipAllReady = result.Ready()
+			logger.Info("subroutine skipped remaining chain", "subroutine", sub.GetName(), "action", actionName, "message", result.Message(), "ready", result.Ready())
+			if l.conditions != nil {
+				var remaining []string
+				for _, r := range subs[i+1:] {
+					remaining = append(remaining, r.GetName())
+				}
+				if len(remaining) > 0 {
+					l.conditions.SetSkippedConditions(obj, remaining, skipAllReady, result.Message())
+				}
+			}
+			break
+		}
 	}
 
 	// Remove initializer/terminator from status if all succeeded with no requeue.
-	if subroutineErr == nil && !hasStopped && !hasPending && minRequeue == 0 {
+	if subroutineErr == nil && !hasStopped && !hasSkipAll && !hasPending && minRequeue == 0 {
 		if l.initializer != "" && !isDeleting {
 			if removeMarkerFromStatus(ctx, obj, statusFieldInitializers, l.initializer) {
 				logger.V(1).Info("removed initializer from status", "initializer", l.initializer)
@@ -307,6 +325,8 @@ func (l *Lifecycle) Reconcile(ctx context.Context, req mcreconcile.Request) (rec
 		case subroutineErr != nil:
 			readyReason = conditions.ReasonError
 		case hasStopped:
+			readyReason = conditions.ReasonStopped
+		case hasSkipAll && !skipAllReady:
 			readyReason = conditions.ReasonStopped
 		case hasPending:
 			readyReason = conditions.ReasonPending

--- a/result.go
+++ b/result.go
@@ -9,6 +9,7 @@ const (
 	actionPending
 	actionStopWithRequeue
 	actionStop
+	actionSkipAll
 )
 
 // Result encodes the outcome of a subroutine invocation.
@@ -17,6 +18,7 @@ type Result struct {
 	action  action
 	requeue time.Duration
 	message string
+	ready   bool
 }
 
 // OK returns a Result that continues the chain with no requeue.
@@ -51,6 +53,13 @@ func Stop(msg string) Result {
 	return Result{action: actionStop, message: msg}
 }
 
+// SkipAll halts the subroutine chain and marks remaining subroutines as Skipped.
+// The ready flag controls the aggregate Ready condition: true sets it to True,
+// false sets it to False.
+func SkipAll(ready bool, msg string) Result {
+	return Result{action: actionSkipAll, message: msg, ready: ready}
+}
+
 // IsContinue returns true if the result is OK or OKWithRequeue.
 // Note: Pending also continues the chain but returns false here — use IsPending
 // to check for that case separately.
@@ -71,6 +80,16 @@ func (r Result) IsStopWithRequeue() bool {
 // IsStop returns true if the result stops the chain with no requeue.
 func (r Result) IsStop() bool {
 	return r.action == actionStop
+}
+
+// IsSkipAll returns true if the result halts the chain and marks remaining subroutines as Skipped.
+func (r Result) IsSkipAll() bool {
+	return r.action == actionSkipAll
+}
+
+// Ready returns the ready flag, which controls the aggregate Ready condition for SkipAll results.
+func (r Result) Ready() bool {
+	return r.ready
 }
 
 // Requeue returns the requeue duration.


### PR DESCRIPTION
## Summary

- Add `SkipAll(ready, message)` result that halts the subroutine chain and marks remaining subroutines' conditions as `Skipped`
- The `ready` flag controls the aggregate Ready condition: `true` = Ready/True, `false` = Ready/False
- Add `ReasonSkipped` constant and `SetSkippedConditions()` to condition manager
- Add `SetSkippedConditions` to `ConditionManager` interface

Implements the SkipAll feature from [RFC 003](https://github.com/platform-mesh/architecture/pull/9). Also fixes the broken build on main where tests for SkipAll were merged without the implementation.