### PR TITLE
feat: add WithRateLimiter for custom work queue rate limiting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/trace v1.36.0
 	k8s.io/apimachinery v0.35.0
+	k8s.io/client-go v0.35.0
 	sigs.k8s.io/controller-runtime v0.23.1
 	sigs.k8s.io/multicluster-runtime v0.23.1
 )
@@ -25,7 +26,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -47,7 +47,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
@@ -59,7 +58,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.35.0 // indirect
 	k8s.io/apiextensions-apiserver v0.35.0 // indirect
-	k8s.io/client-go v0.35.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
 )
 
 var tracer = otel.Tracer("github.com/platform-mesh/subroutines/lifecycle")
@@ -51,6 +52,7 @@ type Lifecycle struct {
 	specPatch      bool
 	initializer    string
 	terminator     string
+	rateLimiter    workqueue.TypedRateLimiter[reconcile.Request]
 }
 
 // New creates a Lifecycle for the given controller.
@@ -125,6 +127,20 @@ func (l *Lifecycle) WithInitializer(name string) *Lifecycle {
 func (l *Lifecycle) WithTerminator(name string) *Lifecycle {
 	l.terminator = name
 	return l
+}
+
+// WithRateLimiter sets a custom rate limiter for the controller's work queue.
+// This controls how fast items re-enter the queue, independent of subroutine-level
+// requeue timing. Accepts any workqueue.TypedRateLimiter implementation.
+func (l *Lifecycle) WithRateLimiter(limiter workqueue.TypedRateLimiter[reconcile.Request]) *Lifecycle {
+	l.rateLimiter = limiter
+	return l
+}
+
+// RateLimiter returns the configured rate limiter, or nil if none was set.
+// This is used by controller setup code to configure the controller's work queue.
+func (l *Lifecycle) RateLimiter() workqueue.TypedRateLimiter[reconcile.Request] {
+	return l.rateLimiter
 }
 
 // Reconcile implements mcreconcile.Reconciler.


### PR DESCRIPTION
## Summary

- Adds `WithRateLimiter(limiter)` builder method to `Lifecycle`, allowing controllers to configure a custom `workqueue.TypedRateLimiter[reconcile.Request]` for their work queue
- Adds `RateLimiter()` getter for controller setup code to retrieve the configured limiter
- Promotes `k8s.io/client-go` from indirect to direct dependency

Implements the `WithRateLimiter` feature from [RFC 003: Runtime Lifecycle v2](https://github.com/platform-mesh/architecture/pull/9).

## Test plan

- `TestWithRateLimiter` (already on main) validates builder/getter round-trip
- `task test` and `task lint` pass cleanly