### PR TITLE
chore: enable renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>platform-mesh/.github:renovate-config"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `renovate.json` extending the shared org-level config from `platform-mesh/.github`
- Enables automated dependency update PRs (Go modules, GitHub Actions digest pinning)
- Matches the setup used across all other platform-mesh repositories