### PR TITLE
feat: add Skip result for bypassing individual subroutines

### DIFF
--- a/conditions/manager.go
+++ b/conditions/manager.go
@@ -76,6 +76,10 @@ func (m *Manager) SetSubroutineCondition(obj client.Object, name string, result 
 		cond.Status = metav1.ConditionFalse
 		cond.Reason = ReasonStopped
 		cond.Message = result.Message()
+	case result.IsSkip():
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = ReasonSkipped
+		cond.Message = result.Message()
 	default:
 		cond.Status = metav1.ConditionTrue
 		cond.Reason = ReasonComplete

--- a/conditions/manager_test.go
+++ b/conditions/manager_test.go
@@ -100,6 +100,13 @@ func TestSetSubroutineCondition(t *testing.T) {
 			wantType:   "mysub",
 		},
 		{
+			name:       "Skip result",
+			result:     subroutines.Skip("not needed"),
+			wantStatus: metav1.ConditionTrue,
+			wantReason: ReasonSkipped,
+			wantType:   "mysub",
+		},
+		{
 			name:       "finalize suffix",
 			result:     subroutines.OK(),
 			isFinalize: true,

--- a/result.go
+++ b/result.go
@@ -10,6 +10,7 @@ const (
 	actionStopWithRequeue
 	actionStop
 	actionSkipAll
+	actionSkip
 )
 
 // Result encodes the outcome of a subroutine invocation.
@@ -60,6 +61,13 @@ func SkipAll(ready bool, msg string) Result {
 	return Result{action: actionSkipAll, message: msg, ready: ready}
 }
 
+// Skip returns a Result that continues the chain but marks the condition as True/Skipped.
+// Use Skip when a subroutine's preconditions are not met and it should be bypassed
+// without interrupting the remaining chain.
+func Skip(msg string) Result {
+	return Result{action: actionSkip, message: msg}
+}
+
 // IsContinue returns true if the result is OK or OKWithRequeue.
 // Note: Pending also continues the chain but returns false here — use IsPending
 // to check for that case separately.
@@ -85,6 +93,11 @@ func (r Result) IsStop() bool {
 // IsSkipAll returns true if the result halts the chain and marks remaining subroutines as Skipped.
 func (r Result) IsSkipAll() bool {
 	return r.action == actionSkipAll
+}
+
+// IsSkip returns true if the result continues the chain with a True/Skipped condition.
+func (r Result) IsSkip() bool {
+	return r.action == actionSkip
 }
 
 // Ready returns the ready flag, which controls the aggregate Ready condition for SkipAll results.

--- a/result_test.go
+++ b/result_test.go
@@ -15,6 +15,7 @@ func TestResult(t *testing.T) {
 		wantPending     bool
 		wantStopRequeue bool
 		wantStop        bool
+		wantSkip        bool
 		wantRequeue     time.Duration
 		wantMessage     string
 	}{
@@ -54,6 +55,12 @@ func TestResult(t *testing.T) {
 			wantStop:    true,
 			wantMessage: "precondition failed",
 		},
+		{
+			name:        "Skip",
+			result:      Skip("not applicable"),
+			wantSkip:    true,
+			wantMessage: "not applicable",
+		},
 	}
 
 	for _, tt := range tests {
@@ -62,6 +69,7 @@ func TestResult(t *testing.T) {
 			assert.Equal(t, tt.wantPending, tt.result.IsPending())
 			assert.Equal(t, tt.wantStopRequeue, tt.result.IsStopWithRequeue())
 			assert.Equal(t, tt.wantStop, tt.result.IsStop())
+			assert.Equal(t, tt.wantSkip, tt.result.IsSkip())
 			assert.Equal(t, tt.wantRequeue, tt.result.Requeue())
 			assert.Equal(t, tt.wantMessage, tt.result.Message())
 		})


### PR DESCRIPTION
  `Skip()` complements `OK()` by signalling that a subroutine was intentionally
  bypassed rather than successfully executed. Both continue the chain, but they
  differ in the condition they report:

  - `OK()`, Status/Reason = True/Complete, the subroutine ran and finished its work.
  - `Skip(msg)`, Status/Reason = True/Skipped, the subroutine's preconditions weren't met
  so it was a no-op.

  Without `Skip()`, a subroutine that decides it has nothing to do must return
  `OK()`, which makes the condition indistinguishable from one that actually
  completed work. The semantics matters here: operators reading conditions
  can now tell at a glance whether a subroutine was executed or deliberately
  skipped, and the message explains why