### PR TITLE
fix(lifecycle): guard spread state update against incomplete reconciliations

### DIFF
--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -336,8 +336,8 @@ func (l *Lifecycle) Reconcile(ctx context.Context, req mcreconcile.Request) (rec
 		l.conditions.SetReadyCondition(obj, readyReason)
 	}
 
-	// Update spread state.
-	if l.spread != nil && !isDeleting && subroutineErr == nil {
+	// Update spread state — only when the full chain completed without stop or pending requeue.
+	if l.spread != nil && !isDeleting && subroutineErr == nil && !hasStopped && minRequeue == 0 {
 		l.spread.UpdateObservedGeneration(obj)
 		l.spread.SetNextReconcileTime(obj)
 		if l.spread.RemoveRefreshLabel(obj) {

--- a/lifecycle/lifecycle_test.go
+++ b/lifecycle/lifecycle_test.go
@@ -789,14 +789,16 @@ func TestInitializer_NotRemovedOnPending(t *testing.T) {
 // --- Fake Spread Manager ---
 
 type fakeSpreadManager struct {
-	reconcileRequired bool
-	requeueDelay      time.Duration
+	reconcileRequired    bool
+	requeueDelay         time.Duration
+	observedGenUpdated   bool
+	nextReconcileTimeSet bool
 }
 
 func (f *fakeSpreadManager) ReconcileRequired(client.Object) bool     { return f.reconcileRequired }
 func (f *fakeSpreadManager) RequeueDelay(client.Object) time.Duration { return f.requeueDelay }
-func (f *fakeSpreadManager) SetNextReconcileTime(client.Object)       {}
-func (f *fakeSpreadManager) UpdateObservedGeneration(client.Object)   {}
+func (f *fakeSpreadManager) SetNextReconcileTime(client.Object)       { f.nextReconcileTimeSet = true }
+func (f *fakeSpreadManager) UpdateObservedGeneration(client.Object)   { f.observedGenUpdated = true }
 func (f *fakeSpreadManager) RemoveRefreshLabel(client.Object) bool    { return false }
 
 func TestSpread_SkipsWhenNotDue(t *testing.T) {
@@ -840,6 +842,68 @@ func TestSpread_ReconcileWhenDue(t *testing.T) {
 	_, err := lc.Reconcile(context.Background(), newReq("test", "default"))
 	require.NoError(t, err)
 	assert.True(t, processCalled, "subroutine should run when spread says due")
+}
+
+func TestSpread_NotAdvancedOnStopWithRequeue(t *testing.T) {
+	obj := newTestObj("test", "default")
+	cl := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(obj).WithStatusSubresource(obj).Build()
+
+	sub := &processorSub{
+		name: "step1",
+		fn: func(context.Context, client.Object) (subroutines.Result, error) {
+			return subroutines.StopWithRequeue(30*time.Second, "rate limited"), nil
+		},
+	}
+
+	sm := &fakeSpreadManager{reconcileRequired: true}
+	lc := setupLifecycle(cl, sub).WithSpread(sm)
+
+	result, err := lc.Reconcile(context.Background(), newReq("test", "default"))
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, result.RequeueAfter)
+	assert.False(t, sm.observedGenUpdated, "observed generation should not be updated when chain stopped with requeue")
+	assert.False(t, sm.nextReconcileTimeSet, "next reconcile time should not be set when chain stopped with requeue")
+}
+
+func TestSpread_NotAdvancedOnPendingWithRequeue(t *testing.T) {
+	obj := newTestObj("test", "default")
+	cl := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(obj).WithStatusSubresource(obj).Build()
+
+	sub := &processorSub{
+		name: "step1",
+		fn: func(context.Context, client.Object) (subroutines.Result, error) {
+			return subroutines.Pending(10*time.Second, "waiting for external resource"), nil
+		},
+	}
+
+	sm := &fakeSpreadManager{reconcileRequired: true}
+	lc := setupLifecycle(cl, sub).WithSpread(sm)
+
+	result, err := lc.Reconcile(context.Background(), newReq("test", "default"))
+	require.NoError(t, err)
+	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+	assert.False(t, sm.observedGenUpdated, "observed generation should not be updated when subroutine is pending")
+	assert.False(t, sm.nextReconcileTimeSet, "next reconcile time should not be set when subroutine is pending")
+}
+
+func TestSpread_AdvancedOnSuccess(t *testing.T) {
+	obj := newTestObj("test", "default")
+	cl := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(obj).WithStatusSubresource(obj).Build()
+
+	sub := &processorSub{
+		name: "step1",
+		fn: func(context.Context, client.Object) (subroutines.Result, error) {
+			return subroutines.OK(), nil
+		},
+	}
+
+	sm := &fakeSpreadManager{reconcileRequired: true}
+	lc := setupLifecycle(cl, sub).WithSpread(sm)
+
+	_, err := lc.Reconcile(context.Background(), newReq("test", "default"))
+	require.NoError(t, err)
+	assert.True(t, sm.observedGenUpdated, "observed generation should be updated on successful reconciliation")
+	assert.True(t, sm.nextReconcileTimeSet, "next reconcile time should be set on successful reconciliation")
 }
 
 // --- incompatible object type ---


### PR DESCRIPTION
## Summary

- Spread state (`ObservedGeneration` + `NextReconcileTime`) was advanced unconditionally after subroutine execution, even when the chain stopped with `StopWithRequeue` or a subroutine returned `Pending` with a requeue duration
- This caused `ReconcileRequired()` to return `false` on the next requeue (generation already matched, `NextReconcileTime` was hours in the future), effectively blocking resources that use `StopWithRequeue` for intermediate waiting states
- Added `!hasStopped && minRequeue == 0` guards to the spread state update, matching the existing pattern at the initializer/terminator removal guard
- The old `golang-commons` implementation had this guard via `MarkResourceAsFinal` which was only called when `result.RequeueAfter == 0`

Reported by @nuromirg — validated with https://github.com/nuromirg/subroutines/commit/3d13b64

## Test plan

- [x] `TestSpread_NotAdvancedOnStopWithRequeue` — verifies spread state is not updated when chain stops with requeue
- [x] `TestSpread_NotAdvancedOnPendingWithRequeue` — verifies spread state is not updated when a subroutine returns Pending
- [x] `TestSpread_AdvancedOnSuccess` — verifies spread state IS updated on successful completion
- [x] All existing tests pass
- [x] Lint clean