### PR TITLE
Add OpenSSF Scorecard schedule

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,0 +1,18 @@
+name: OpenSSF Scorecard
+on:
+    push:
+        branches: [main]
+    schedule:
+        - cron: '30 4 * * 1'
+    workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+    scorecard:
+        uses: platform-mesh/.github/.github/workflows/job-ossf-scorecard.yml@main
+        permissions:
+            security-events: write
+            id-token: write
+            contents: read
+            actions: read

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Platform Mesh - subroutines
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/platform-mesh/subroutines/badge)](https://scorecard.dev/viewer/?uri=github.com/platform-mesh/subroutines)
 [![CI](https://github.com/platform-mesh/subroutines/actions/workflows/pipeline.yml/badge.svg)](https://github.com/platform-mesh/subroutines/actions/workflows/pipeline.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/platform-mesh/subroutines.svg)](https://pkg.go.dev/github.com/platform-mesh/subroutines)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)


### PR DESCRIPTION
Releates to https://github.com/platform-mesh/backlog/issues/227

Enables the OpenSSF Scorecard by calling a schedule workflow every monday at 4:30 AM.
Seperate Pipeline because the Scorecard should only run by pushes on main and scheduled.